### PR TITLE
:herb: .fernignore semgrep github workflow

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,3 +4,5 @@ README.md
 
 # We need to configure secrets for integration tests.
 .github/workflows/ci.yml
+
+.github/workflows/semgrep.yml


### PR DESCRIPTION
This PR adds `semgrep.yml` to the `.fernignore` file. When fern generates the SDKs it makes sure to not overwrite anything in the `.fernignore`.