### PR TITLE
Fix typo in README for GET Candidate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ merge_client = Merge(
     api_key="<YOUR_API_KEY>", 
     account_token="<YOUR_ACCOUNT_TOKEN>")
 
-candidate = merge_client.ats.candiates.retrieve(
+candidate = merge_client.ats.candidates.retrieve(
     id="521b18c2-4d01-4297-b451-19858d07c133")
 ```
 


### PR DESCRIPTION
- Fix typo `merge_client.ats.candiates.list(` to `merge_client.ats.candidates.list(`