### PR TITLE
Trigger `ci.yml` on all push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ on:
   # allow manual triggering
   workflow_dispatch: {}
   # full scan on push to master
-  push:
-    branches: ["main"]
+  push: {}
 jobs:
   compile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We were previously filtering out push events that were triggered on a tag, which always results in skpping the publish job.