### PR TITLE
:herb: Update permissions type

### DIFF
--- a/src/merge/resources/filestorage/types/file.py
+++ b/src/merge/resources/filestorage/types/file.py
@@ -28,7 +28,7 @@ class File(pydantic.BaseModel):
     mime_type: typing.Optional[str] = pydantic.Field(description="The file's mime type.")
     description: typing.Optional[str] = pydantic.Field(description="The file's description.")
     folder: typing.Optional[str] = pydantic.Field(description="The folder that the file belongs to.")
-    permissions: typing.List[str] = pydantic.Field(
+    permissions: typing.Union[str, typing.List[str]] = pydantic.Field(
         description="The Permission object is used to represent a user's or group's access to a File or Folder. Permissions are unexpanded by default. Use the query param `expand=permissions` to see more details under `GET /files`."
     )
     drive: typing.Optional[str] = pydantic.Field(description="The drive that the file belongs to.")


### PR DESCRIPTION
This is a manual PR to fix the typing of `permissions` so that the file download endpoint is usable. 