### PR TITLE
Fix remote_fields Definition in Pydantic Models to Make Field Optional and Nullable

### DIFF
--- a/src/merge/resources/accounting/types/contact.py
+++ b/src/merge/resources/accounting/types/contact.py
@@ -109,7 +109,7 @@ class Contact(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/accounting/types/expense.py
+++ b/src/merge/resources/accounting/types/expense.py
@@ -428,7 +428,7 @@ class Expense(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/accounting/types/invoice.py
+++ b/src/merge/resources/accounting/types/invoice.py
@@ -483,7 +483,7 @@ class Invoice(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/accounting/types/invoice_line_item.py
+++ b/src/merge/resources/accounting/types/invoice_line_item.py
@@ -405,7 +405,7 @@ class InvoiceLineItem(UniversalBaseModel):
     """
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/accounting/types/journal_entry.py
+++ b/src/merge/resources/accounting/types/journal_entry.py
@@ -434,7 +434,7 @@ class JournalEntry(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/accounting/types/journal_line.py
+++ b/src/merge/resources/accounting/types/journal_line.py
@@ -393,7 +393,7 @@ class JournalLine(UniversalBaseModel):
     Indicates whether or not this object has been deleted in the third party platform. Full coverage deletion detection is a premium add-on. Native deletion detection is offered for free with limited coverage. [Learn more](https://docs.merge.dev/integrations/hris/supported-features/).
     """
 
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/accounting/types/payment.py
+++ b/src/merge/resources/accounting/types/payment.py
@@ -419,7 +419,7 @@ class Payment(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/accounting/types/payment_line_item.py
+++ b/src/merge/resources/accounting/types/payment_line_item.py
@@ -20,7 +20,7 @@ class PaymentLineItem(UniversalBaseModel):
     `Payment` will have a field called `applied-to-lines` which will be an array of `PaymentLineItemInternalMappingSerializer` objects that can either be a `Invoice`, `CreditNote`, or `JournalEntry`.
     """
 
-    id: typing.Optional[str]
+    id: typing.Optional[typing.Any] = None
     remote_id: typing.Optional[str] = pydantic.Field()
     """
     The third-party API ID of the matching object.
@@ -46,12 +46,12 @@ class PaymentLineItem(UniversalBaseModel):
     The date the payment portion is applied.
     """
 
-    related_object_id: typing.Optional[str] = pydantic.Field()
+    related_object_id: typing.Optional[str] = None
     """
     The Merge ID of the transaction the payment portion is being applied to.
     """
 
-    related_object_type: typing.Optional[str] = pydantic.Field()
+    related_object_type: typing.Optional[str] = None
     """
     The type of transaction the payment portion is being applied to. Possible values include: INVOICE, JOURNAL_ENTRY, or CREDIT_NOTE.
     """

--- a/src/merge/resources/accounting/types/purchase_order.py
+++ b/src/merge/resources/accounting/types/purchase_order.py
@@ -450,7 +450,7 @@ class PurchaseOrder(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/accounting/types/purchase_order_line_item.py
+++ b/src/merge/resources/accounting/types/purchase_order_line_item.py
@@ -412,7 +412,7 @@ class PurchaseOrderLineItem(UniversalBaseModel):
     Indicates whether or not this object has been deleted in the third party platform. Full coverage deletion detection is a premium add-on. Native deletion detection is offered for free with limited coverage. [Learn more](https://docs.merge.dev/integrations/hris/supported-features/).
     """
 
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/account.py
+++ b/src/merge/resources/crm/types/account.py
@@ -95,7 +95,7 @@ class Account(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/contact.py
+++ b/src/merge/resources/crm/types/contact.py
@@ -83,7 +83,7 @@ class Contact(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/custom_object.py
+++ b/src/merge/resources/crm/types/custom_object.py
@@ -47,7 +47,7 @@ class CustomObject(UniversalBaseModel):
     The fields and values contained within the custom object record.
     """
 
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/engagement.py
+++ b/src/merge/resources/crm/types/engagement.py
@@ -94,7 +94,7 @@ class Engagement(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/engagement_type.py
+++ b/src/merge/resources/crm/types/engagement_type.py
@@ -52,7 +52,7 @@ class EngagementType(UniversalBaseModel):
     The engagement type's name.
     """
 
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/lead.py
+++ b/src/merge/resources/crm/types/lead.py
@@ -109,7 +109,7 @@ class Lead(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/note.py
+++ b/src/merge/resources/crm/types/note.py
@@ -84,7 +84,7 @@ class Note(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/opportunity.py
+++ b/src/merge/resources/crm/types/opportunity.py
@@ -103,7 +103,7 @@ class Opportunity(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/stage.py
+++ b/src/merge/resources/crm/types/stage.py
@@ -50,7 +50,7 @@ class Stage(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/task.py
+++ b/src/merge/resources/crm/types/task.py
@@ -92,7 +92,7 @@ class Task(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/crm/types/user.py
+++ b/src/merge/resources/crm/types/user.py
@@ -60,7 +60,7 @@ class User(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/src/merge/resources/ticketing/types/ticket.py
+++ b/src/merge/resources/ticketing/types/ticket.py
@@ -139,7 +139,7 @@ class Ticket(UniversalBaseModel):
 
     field_mappings: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]]
     remote_data: typing.Optional[typing.List[RemoteData]]
-    remote_fields: typing.Optional[typing.List[RemoteField]]
+    remote_fields: typing.Optional[typing.List[RemoteField]] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2


### PR DESCRIPTION
This PR corrects the field definition of "remote_fields" in the Pydantic models, which was causing validation errors. Previously, the omission of = None at the end of the field definition inadvertently made the field required, despite it being nullable. Since the remote_fields field is not present in every API response and should be both optional and nullable, this update properly adjusts its definition.

Changes:

- Updated the remote_fields field in the Pydantic models to include = None, ensuring it is treated as an optional field that can be None when not present in the API response.

Context:
This change resolves validation errors encountered during the parsing of API responses where remote_fields was missing, and the Pydantic models incorrectly treated it as a required field.

Testing:

- Verified that the models now properly handle cases where remote_fields is omitted or returns an empty array.
- Confirmed that responses with or without this field pass validation without errors.

Reference:
https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields
Field definition F4 (required, nullable) is correct here.
See also:
https://github.com/merge-api/merge-python-client/issues/98