### PR TITLE
Handle expand query params as comma separated list

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -8,3 +8,6 @@ LICENSE.md
 
 # Files that avoid breaking changes due to renames.
 src/merge/resources/accounting/types/currency_enum.py
+
+# File that encodes enum query params as comma separated lists by default
+src/merge/core/query_encoder.py

--- a/src/merge/core/query_encoder.py
+++ b/src/merge/core/query_encoder.py
@@ -24,6 +24,9 @@ def traverse_query_dict(dict_flat: Dict[str, Any], key_prefix: Optional[str] = N
 
 
 def single_query_encoder(query_key: str, query_value: Any) -> List[Tuple[str, Any]]:
+    # Special-case for 'expand' parameter: join lists into a comma-separated string
+    if query_key == "expand" and isinstance(query_value, list):
+        return [(query_key, ",".join(str(x) for x in query_value))]
     if isinstance(query_value, pydantic.BaseModel) or isinstance(query_value, dict):
         if isinstance(query_value, pydantic.BaseModel):
             obj_dict = query_value.dict(by_alias=True)


### PR DESCRIPTION
I created a custom test with the following code, which generated a successful response:

```
import os
import pytest
from merge import Merge
from merge.resources.accounting.resources.invoices.types import (
    InvoicesListRequestExpand,
    InvoicesListRequestType,
    InvoicesListRequestStatus,
)


# Get started with writing tests with pytest at https://docs.pytest.org
@pytest.mark.skip(reason="Unimplemented")
def test_client() -> None:
    assert True


def test_list_invoices_with_expand():
    client = Merge(
        api_key=api_key,
        account_token=account_token,
    )
    expand = [
        InvoicesListRequestExpand.EMPLOYEE,
        InvoicesListRequestExpand.ACCOUNTING_PERIOD,
        InvoicesListRequestExpand.APPLIED_CREDIT_NOTES,
        InvoicesListRequestExpand.CONTACT,
        InvoicesListRequestExpand.PAYMENT_TERM,
    ]
    result = client.accounting.invoices.list(
        expand=expand,
        include_remote_data=True,
        page_size=100,
        type=InvoicesListRequestType.ACCOUNTS_RECEIVABLE,
        status=InvoicesListRequestStatus.OPEN,
    )
    for invoice in result.results:
        print(f"Invoice ID: {invoice.id}")
```

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/93411f4d-ba86-4013-829a-5ab21c8bfc9f" />
